### PR TITLE
Support for CA certs

### DIFF
--- a/config/mrepo-example.conf
+++ b/config/mrepo-example.conf
@@ -207,4 +207,5 @@ metadata = repomd repoview
 os = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os
 sslkey = /usr/share/keys/key.pem
 sslcert = /usr/share/keys/cert.pem
+sslca = /etc/rhsm/ca/redhat-uep.pem
 

--- a/mrepo
+++ b/mrepo
@@ -343,6 +343,8 @@ class Config:
                             dist.sslcert = self.cfg.get(section, option)
                         elif option in ('sslkey',):
                             dist.sslkey = self.cfg.get(section, option)
+                        elif option in ('sslca',):
+                            dist.sslca = self.cfg.get(section, option)
                         else:
                             dist.repos.append(Repo(option, self.cfg.get(section, option), dist, self))
 
@@ -391,6 +393,7 @@ class Dist:
         self.disabled = False
         self.sslcert = None
         self.sslkey = None
+        self.sslca = None
 
 #   def __repr__(self):
 #       for key, value in vars(self).iteritems():
@@ -1372,6 +1375,8 @@ def mirrorlftp(url, path, dist):
         cmds = cmds + ' set ssl:cert-file ' + dist.sslcert + ';'
     if dist.sslkey:
         cmds = cmds + ' set ssl:key-file ' + dist.sslkey + ';'    
+    if dist.sslca:
+        cmds = cmds + ' set ssl:ca-file ' + dist.sslca + ' ;'
     
 #   cmds = 'set dns:fatal-timeout 5'
     if cf.lftptimeout:


### PR DESCRIPTION
RHN requires the redhat-uep.pem cert, which may not be in the system-wide ca-bundle.crt. This allows the file to be specified in the config file.
