### PR TITLE
Add support for IBM ppc64le architecture.

### DIFF
--- a/mrepo
+++ b/mrepo
@@ -46,7 +46,7 @@ archs = {
     'i386': ('i386', 'i486', 'i586', 'i686', 'athlon'),
     'ia64': ('i386', 'i686', 'ia64'),
     'ppc': ('ppc', ),
-    'ppc64': ('ppc', 'ppc64', 'ppc64pseries', 'ppc64iseries'),
+    'ppc64': ('ppc', 'ppc64', 'ppc64le', 'ppc64pseries', 'ppc64iseries'),
     'x86_64': ('i386', 'i486', 'i586', 'i686', 'athlon', 'x86_64', 'amd64', 'ia32e'),
     'sparc64': ('sparc', 'sparcv8', 'sparcv9', 'sparc64'),
     'sparc64v': ('sparc', 'sparcv8', 'sparcv9', 'sparcv9v', 'sparc64', 'sparc64v'),


### PR DESCRIPTION
IBM Power line of processors now includes the architecture ppc46le
with matching architecture identifiers in repository URLs.  Add
value of ppc64le to archs so mrepo will view this value as a valid
architecture when used in configuration files.